### PR TITLE
Move item tally increase to checkout

### DIFF
--- a/src/main/java/sim/coffee/OrderBasket.java
+++ b/src/main/java/sim/coffee/OrderBasket.java
@@ -20,7 +20,7 @@ public class OrderBasket extends OrderList {
         orderList = o;
     }
 
-    // Method to check if order is a sandwich, 
+    // Method to check if order is a sandwich,
     // Only used for the breakfast deal - discount1()
     public boolean ifSandwich(Order o) {
         // Use Regex to track the food item and return a boolean - true, if item is a sandwich
@@ -144,6 +144,12 @@ public class OrderBasket extends OrderList {
     // Dumps basket contents into permanent order list and emptys the basket
     public boolean checkout() {
         boolean added = orderList.addAll(this.orders);
+
+        // Item count should increment now that they're purchased
+        for (Order o : orders) {
+            menu.getItem(o.getItemId()).setCount();
+        }
+
         orders.clear();
         return added;
     }
@@ -155,9 +161,6 @@ public class OrderBasket extends OrderList {
 
         // Discounts should be updated each time an item is added
         applyDiscount(o);
-
-        // Item count should increment (move to checkout if we enable "remove from basket")
-        menu.getItem(o.getItemId()).setCount();
 
         return added;
     }
@@ -206,7 +209,7 @@ public class OrderBasket extends OrderList {
         }
 
         if (orderList.getDayIncome(today).signum() > 0) {
-            report += "\n" + "The most popular menu item(s) today: " 
+            report += "\n" + "The most popular menu item(s) today: "
             + mostPopularItem + "ordered " + highestCount + " times";
         } else {
             report += "\n" + "No items are being sold today, don't give up, try again tomorrow! :)";

--- a/src/test/java/sim/coffee/OrderBasketTest.java
+++ b/src/test/java/sim/coffee/OrderBasketTest.java
@@ -71,17 +71,21 @@ public class OrderBasketTest {
     }
 
     /**
-     * Tests that upon adding a new order the menu item order tally is incremented
-     * (tallying may be moved to checkout in future)
+     * Tests that upon checkout the menu item order tally is incremented for each
+     * instance in the basket
      */
     @Test
     public void itemTallyIncrease() {
         int tallyBefore = testMenu.getItem("F001").getOrderCount();
 
         testBasket.add(testOrder);
+        testBasket.add(testOrder);
+        testBasket.add(testOrder);
+        testBasket.add(testOrder);
+        testBasket.checkout();
 
         // The corresponding item should be tallied once
-        assertEquals(tallyBefore + 1, testMenu.getItem("F001").getOrderCount());
+        assertEquals(tallyBefore + 4, testMenu.getItem("F001").getOrderCount());
     }
 
     /**


### PR DESCRIPTION
This fixes the possibility for the output report to give the wrong tally for number of items ordered if the GUI is closed with items in the basket.