### PR TITLE
Fix price scaling when limited sizes available

### DIFF
--- a/src/main/java/sim/coffee/Beverage.java
+++ b/src/main/java/sim/coffee/Beverage.java
@@ -38,11 +38,16 @@ public class Beverage extends MenuItem {
 
 	// Chosen size and milk changes the price of this item
 	public BigDecimal getPrice(Size s, Milk m) {
+		// Smallest possible size recieves base price, scale coefficients accordingly
+		// (i.e. wouldn't make sense to multiply if only "large" is available)
+		// note: sizes must always be listed smallest to largest in data
+		double scaledCoef = s.getCoefficient() / sizes[0].getCoefficient();
+
 		// Milk adds to the price
 		BigDecimal withMilk = getPrice().add(BigDecimal.valueOf(m.getAddOnPrice()));
 
 		// Size increases quantity of milk too as a coefficient
-		BigDecimal price = withMilk.multiply(BigDecimal.valueOf(s.getCoefficient()));
+		BigDecimal price = withMilk.multiply(BigDecimal.valueOf(scaledCoef));
 
 		return roundPrice(price);
 	}


### PR DESCRIPTION
It was unintuitive that the price of a beverage would scale up from the base price when selecting the smallest size if Small was not an option.

I just fixed this by dividing the coefficient by the smallest available.

Fixes #53