### PR TITLE
Implement Log instance in SharedQueue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hs_err_pid*
 /target/
 
 report.txt
+log.txt

--- a/src/main/java/sim/coffee/Log.java
+++ b/src/main/java/sim/coffee/Log.java
@@ -33,7 +33,7 @@ public class Log {
 		log.append(String.format("%-25s", "Customer ID: " + o[0].getCustomerID()));
 		log.append(String.format("%-7s", "Order: "));
 		for (Order order : o) {
-			log.append(order.getItemDetails());
+			log.append(order.getItemDetails() + " ");
 		}
 		log.append("\n");
 	}

--- a/src/main/java/sim/coffee/Logger.java
+++ b/src/main/java/sim/coffee/Logger.java
@@ -5,14 +5,14 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 
 public class Logger {
-	
+
 	//enums for the add() method
 	public enum OrderState {
 		ENTER,
 		EXIT,
 		PROCESSED;
 	}
-	
+
 	private static Logger instance;
 	private StringBuilder log;
 
@@ -21,10 +21,10 @@ public class Logger {
 	}
 
 	//adds an entry in the log when an order is added to queue (enter), removed from queue (exit) or processed (processed)
-	public void add(Order[] o, Logger.OrderState state) {
+	public void add(Order[] o, OrderState state) {
 		LocalDateTime time = LocalDateTime.now();
 		log.append(String.format("%-35s", time));
-		
+
 		switch (state) {
 		case ENTER:
 			log.append(String.format("%-15s", "Enter queue"));

--- a/src/main/java/sim/coffee/Logger.java
+++ b/src/main/java/sim/coffee/Logger.java
@@ -5,6 +5,14 @@ import java.io.IOException;
 import java.time.LocalDate;
 
 public class Logger {
+	
+	//enums for the add() method
+	public enum OrderState {
+		ENTER,
+		EXIT,
+		PROCESSED;
+	}
+	
 	private static Logger instance;
 	private StringBuilder log;
 
@@ -12,20 +20,19 @@ public class Logger {
 		log = new StringBuilder();
 	}
 
-
 	//adds an entry in the log when an order is added to queue (enter), removed from queue (exit) or processed (processed)
-	public void add(Order[] o, String state) {
+	public void add(Order[] o, Logger.OrderState state) {
 		LocalDate time = LocalDate.now();
 		log.append(String.format("%-15s", time));
-
-		switch (state.toLowerCase()) {
-		case "enter":
+		
+		switch (state) {
+		case ENTER:
 			log.append(String.format("%-15s", "Enter queue"));
 			break;
-		case "exit":
+		case EXIT:
 			log.append(String.format("%-15s", "Exit queue"));
 			break;
-		case "processed":
+		case PROCESSED:
 			log.append(String.format("%-15s", "Processed"));
 			break;
 		}

--- a/src/main/java/sim/coffee/Logger.java
+++ b/src/main/java/sim/coffee/Logger.java
@@ -4,20 +4,20 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.time.LocalDate;
 
-public class Log {
-	private static Log instance;
+public class Logger {
+	private static Logger instance;
 	private StringBuilder log;
-	
-	private Log() {
+
+	private Logger() {
 		log = new StringBuilder();
 	}
 
-	
+
 	//adds an entry in the log when an order is added to queue (enter), removed from queue (exit) or processed (processed)
 	public void add(Order[] o, String state) {
 		LocalDate time = LocalDate.now();
 		log.append(String.format("%-15s", time));
-		
+
 		switch (state.toLowerCase()) {
 		case "enter":
 			log.append(String.format("%-15s", "Enter queue"));
@@ -29,7 +29,7 @@ public class Log {
 			log.append(String.format("%-15s", "Processed"));
 			break;
 		}
-		
+
 		log.append(String.format("%-25s", "Customer ID: " + o[0].getCustomerID()));
 		log.append(String.format("%-7s", "Order: "));
 		for (Order order : o) {
@@ -37,21 +37,21 @@ public class Log {
 		}
 		log.append("\n");
 	}
-	
-	
+
+
 	//returns instance of the Log class
-	public static Log getInstance() {
+	public static Logger getInstance() {
 		if (instance == null)
-			instance = new Log();
+			instance = new Logger();
 		return instance;
 	}
-	
+
 	public StringBuilder getLog() {
 		return log;
 	}
-	
-	//writes log to file 
-	public void writeReport(String filename) {	
+
+	//writes log to file
+	public void writeReport(String filename) {
         try (FileWriter orderWriter = new FileWriter(filename)) {
 			orderWriter.write(log.toString());
 		} catch(IOException e) {

--- a/src/main/java/sim/coffee/Logger.java
+++ b/src/main/java/sim/coffee/Logger.java
@@ -2,7 +2,7 @@ package sim.coffee;
 
 import java.io.FileWriter;
 import java.io.IOException;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class Logger {
 	
@@ -22,8 +22,8 @@ public class Logger {
 
 	//adds an entry in the log when an order is added to queue (enter), removed from queue (exit) or processed (processed)
 	public void add(Order[] o, Logger.OrderState state) {
-		LocalDate time = LocalDate.now();
-		log.append(String.format("%-15s", time));
+		LocalDateTime time = LocalDateTime.now();
+		log.append(String.format("%-35s", time));
 		
 		switch (state) {
 		case ENTER:
@@ -38,9 +38,9 @@ public class Logger {
 		}
 
 		log.append(String.format("%-25s", "Customer ID: " + o[0].getCustomerID()));
-		log.append(String.format("%-7s", "Order: "));
+		log.append(String.format("%-7s", "Order ID: "));
 		for (Order order : o) {
-			log.append(order.getItemDetails() + " ");
+			log.append(order.getItemId() + " ");
 		}
 		log.append("\n");
 	}

--- a/src/main/java/sim/coffee/Server.java
+++ b/src/main/java/sim/coffee/Server.java
@@ -21,6 +21,7 @@ public class Server implements Runnable{
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
+        	log.add(order, Logger.OrderState.PROCESSED);
         }
         log.writeReport("log.txt");
     }

--- a/src/main/java/sim/coffee/Server.java
+++ b/src/main/java/sim/coffee/Server.java
@@ -2,9 +2,11 @@ package sim.coffee;
 
 public class Server implements Runnable{
     private SharedQueue queue;
+    private Logger log;
 
     public Server(SharedQueue queue) {
         this.queue = queue;
+        log = Logger.getInstance();
     }
 
     /**
@@ -12,13 +14,15 @@ public class Server implements Runnable{
      */
     @Override
     public void run() {
-        while (!queue.getDone() && !queue.isEmpty()) {
-            try {
+        while (!queue.getDone()) {
+            Order [] order = queue.getCustomerOrder();
+        	try {
                 // Tries to simulate no. of orders * time it take to prepare one order
-                // queue.getCustomerOrder() // TODO: Implement in the future
-                int orderSize = queue.getCustomerOrder().length;
-                Thread.sleep(2000*orderSize);
+                int orderSize = order.length;
+                Thread.sleep(5000 * orderSize);
+                
             } catch (InterruptedException e) {}
         }
+        log.writeReport("log.txt");
     }
 }

--- a/src/main/java/sim/coffee/Server.java
+++ b/src/main/java/sim/coffee/Server.java
@@ -16,11 +16,11 @@ public class Server implements Runnable{
         while (!queue.getDone() || !queue.isEmpty()) {
             Order [] order = queue.getCustomerOrder();
         	try {
-                // Tries to simulate no. of orders * time it take to prepare one order
-                int orderSize = order.length;
-                Thread.sleep(5000 * orderSize);
-                
-            } catch (InterruptedException e) {}
+                // Time to process order depends on number of items
+                Thread.sleep(10000l * order.length);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
         log.writeReport("log.txt");
     }

--- a/src/main/java/sim/coffee/Server.java
+++ b/src/main/java/sim/coffee/Server.java
@@ -9,12 +9,11 @@ public class Server implements Runnable{
         log = Logger.getInstance();
     }
 
-    /**
-     * Run only while its not done and queue isn't empty
-     */
     @Override
     public void run() {
-        while (!queue.getDone()) {
+        // Service continues as long as customers are still due to arrive or customers
+        // are in the queue
+        while (!queue.getDone() || !queue.isEmpty()) {
             Order [] order = queue.getCustomerOrder();
         	try {
                 // Tries to simulate no. of orders * time it take to prepare one order

--- a/src/main/java/sim/coffee/SharedQueue.java
+++ b/src/main/java/sim/coffee/SharedQueue.java
@@ -7,13 +7,13 @@ public class SharedQueue {
 	private LinkedList<Order[]> queue;
 	private boolean empty;
 	private boolean done;
-	private Log log;
+	private Logger log;
 
 	public SharedQueue() {
 		queue = new LinkedList<Order[]>();
 		empty = true;
 		done = false;
-		log = Log.getInstance();
+		log = Logger.getInstance();
 	}
 
 	// returns an array of order at the top of the queue

--- a/src/main/java/sim/coffee/SharedQueue.java
+++ b/src/main/java/sim/coffee/SharedQueue.java
@@ -7,11 +7,13 @@ public class SharedQueue {
 	private LinkedList<Order[]> queue;
 	private boolean empty;
 	private boolean done;
+	private Log log;
 
 	public SharedQueue() {
 		queue = new LinkedList<Order[]>();
 		empty = true;
 		done = false;
+		log = Log.getInstance();
 	}
 
 	// returns an array of order at the top of the queue
@@ -26,18 +28,21 @@ public class SharedQueue {
 		}
 
 		Order[] customerOrder = queue.getFirst();
+		log.add(customerOrder, "exit");
 		queue.removeFirst();
 
 		if (queue.size() == 0) {
 			empty = true;
 			notifyAll();
 		}
+		
 		return customerOrder;
 	}
 
 	// adds an array of orders to the queue
 	public synchronized void addOrder(Order[] o) {
 		queue.addLast(o);
+		log.add(o, "enter"); //adds an entry in the log every time the method is called
 		empty = false;
 		notifyAll();
 	}
@@ -62,7 +67,4 @@ public class SharedQueue {
  		}
  		return queueLog;
  	}
-
-    public void addOrder(Object[] array) {
-    }
 }

--- a/src/main/java/sim/coffee/SharedQueue.java
+++ b/src/main/java/sim/coffee/SharedQueue.java
@@ -30,7 +30,7 @@ public class SharedQueue {
 		log.add(customerOrder, Logger.OrderState.EXIT);
 		queue.removeFirst();
 
-		if (queue.size() == 0) {
+		if (queue.isEmpty()) {
 			empty = true;
 			notifyAll();
 		}

--- a/src/main/java/sim/coffee/SharedQueue.java
+++ b/src/main/java/sim/coffee/SharedQueue.java
@@ -28,7 +28,7 @@ public class SharedQueue {
 		}
 
 		Order[] customerOrder = queue.getFirst();
-		log.add(customerOrder, "exit");
+		log.add(customerOrder, Logger.OrderState.EXIT);
 		queue.removeFirst();
 
 		if (queue.size() == 0) {
@@ -42,7 +42,7 @@ public class SharedQueue {
 	// adds an array of orders to the queue
 	public synchronized void addOrder(Order[] o) {
 		queue.addLast(o);
-		log.add(o, "enter"); //adds an entry in the log every time the method is called
+		log.add(o, Logger.OrderState.ENTER); //adds an entry in the log every time the method is called
 		empty = false;
 		notifyAll();
 	}

--- a/src/main/java/sim/coffee/SharedQueue.java
+++ b/src/main/java/sim/coffee/SharedQueue.java
@@ -21,9 +21,8 @@ public class SharedQueue {
 		while (empty) {
 			try {
 				wait();
-			}
-		 	catch (InterruptedException e) {
-		 		e.printStackTrace();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
 		 	}
 		}
 

--- a/src/main/java/sim/coffee/SharedQueue.java
+++ b/src/main/java/sim/coffee/SharedQueue.java
@@ -4,17 +4,10 @@ import java.util.LinkedList;
 
 public class SharedQueue {
 
-	private LinkedList<Order[]> queue;
-	private boolean empty;
-	private boolean done;
-	private Logger log;
-
-	public SharedQueue() {
-		queue = new LinkedList<Order[]>();
-		empty = true;
-		done = false;
-		log = Logger.getInstance();
-	}
+	private LinkedList<Order[]> queue = new LinkedList<>();
+	private boolean empty = true;
+	private boolean done = false;
+	private Logger log = Logger.getInstance();
 
 	// returns an array of order at the top of the queue
 	public synchronized Order[] getCustomerOrder() {


### PR DESCRIPTION
I've added a Log instance to SharedQueue to allow `addOrder()` and `getCustomerOrder()` use the same one (instead of having to get separate instances for both producer and consumer classes).

Turns out `add()` from Log class was working fine all along, it was the way I was testing it that gave the impression that it wasn't.