### PR TITLE
Fix producer not adding final order

### DIFF
--- a/src/main/java/sim/model/Producer.java
+++ b/src/main/java/sim/model/Producer.java
@@ -75,6 +75,9 @@ public class Producer implements Runnable {
                 lineNum++;
             }
 
+            // Add final customer's order
+            out.addOrder(basket.toArray(Order[]::new));
+
             // Once end of file is reached mark the queue as completed
             out.setDone();
         } catch (FileNotFoundException e) {


### PR DESCRIPTION
Simple enough fix, the producer adds an order on the following loop when a new customer ID is encountered. So this just adds the final order when the loop exits.