### PR TITLE
Make singleton lazy-loading thread safe

### DIFF
--- a/src/main/java/sim/model/Logger.java
+++ b/src/main/java/sim/model/Logger.java
@@ -80,8 +80,10 @@ public class Logger {
 		log.append("\n");
 	}
 
-	//returns instance of the Log class
-	public static Logger getInstance() {
+	// Laze-loads the singleton instance of the class
+	// Synchronized whole method to avoid double-checked locking
+	// (shown in lectures, but discouraged in modern Java practice)
+	public static synchronized Logger getInstance() {
 		if (instance == null)
 			instance = new Logger();
 		return instance;


### PR DESCRIPTION
Was originally going to use double-checked locking for this (as shown in the lectures), but SonarLint (built into VSCode's Java support) flagged it up and upon reading into it apparently it's discouraged due to unreliability without further code to make it thread safe (can be issues with partially instantiated objects).

Making the whole method synchronised is apparently a recommended approach now:

> With early versions of the JVM, synchronizing the whole method was generally advised against for performance reasons. But synchronized performance has improved a lot in newer JVMs, so this is now a preferred solution.


Fixes #101