### PR TITLE
Simplify logger and improve logged events

### DIFF
--- a/src/main/java/sim/model/CoffeeShop.java
+++ b/src/main/java/sim/model/CoffeeShop.java
@@ -25,6 +25,8 @@ public class CoffeeShop implements Subject, Observer {
     private Kitchen kitchen = new Kitchen(orders);
 
     public CoffeeShop(Menu menu, int numStaff) {
+		Logger.getInstance().add("Simulation initiated");
+
         // Producer inserts input file of orders into shared queue for staff
         Thread producer = new Thread(new Producer(
             new File("data/orders.csv"),
@@ -106,6 +108,7 @@ public class CoffeeShop implements Subject, Observer {
         // When kitchen is done coffee shop can close
         // Output log, report and notify observers
         if (kitchen.isDone()) {
+			Logger.getInstance().add("Simulation completed");
             Logger.getInstance().writeReport("log.txt");
             new ReportWriter(kitchen.getServedCustomers()).write(new File("report.txt"));
             notifyObservers();

--- a/src/main/java/sim/model/CoffeeShop.java
+++ b/src/main/java/sim/model/CoffeeShop.java
@@ -11,9 +11,9 @@ import sim.interfaces.Subject;
 public class CoffeeShop implements Subject, Observer {
     // Queue of orders populated by producer for staff to serve
     // Staff then populate the kitchen queue
-    private SharedQueue customers = new SharedQueue(QueueType.CUSTOMER);
-    private SharedQueue priorityCustomers = new SharedQueue(QueueType.PRIORITY);
-    private SharedQueue orders = new SharedQueue(QueueType.KITCHEN);
+    private SharedQueue customers = new SharedQueue();
+    private SharedQueue priorityCustomers = new SharedQueue();
+    private SharedQueue orders = new SharedQueue();
 
     // List of registered observers for observer/subject pattern
     private LinkedList<Observer> observers = new LinkedList<>();

--- a/src/main/java/sim/model/Kitchen.java
+++ b/src/main/java/sim/model/Kitchen.java
@@ -51,7 +51,7 @@ public class Kitchen implements Runnable, Subject {
 
                 // Log order as completed
                 completed.add(toServe);
-                log.add(toServe, Logger.OrderState.SERVED, kitchenQueue.getQueueType());
+                log.add("The kitchen serves %s", toServe);
 
                 // Update model state to reflect customer served
                 currentCustomer = Optional.empty();

--- a/src/main/java/sim/model/Kitchen.java
+++ b/src/main/java/sim/model/Kitchen.java
@@ -41,6 +41,7 @@ public class Kitchen implements Runnable, Subject {
                 Customer toServe = currentCustomer.get();
 
                 notifyObservers();
+				log.add("The kitchen starts preparing an order for %s", toServe);
 
                 try {
                     // Time to process order depends on number of items

--- a/src/main/java/sim/model/Logger.java
+++ b/src/main/java/sim/model/Logger.java
@@ -7,7 +7,7 @@ import java.time.format.DateTimeFormatter;
 
 public class Logger {
 	// Don't want millisecond precious for a log file
-	DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
+	DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
 
 	private static Logger instance;
 	private StringBuilder log;

--- a/src/main/java/sim/model/Logger.java
+++ b/src/main/java/sim/model/Logger.java
@@ -3,8 +3,11 @@ package sim.model;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class Logger {
+	// Don't want millisecond precious for a log file, space at end to distinguish column
+	DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss ");
 
 	//enums for the add() method
 	public enum OrderState {
@@ -25,8 +28,7 @@ public class Logger {
 
 	//adds an entry in the log when an order is added to queue (enter), removed from queue (exit) or processed (processed)
 	public synchronized void add(Customer c, OrderState state, QueueType q) {
-		LocalDateTime time = LocalDateTime.now();
-		log.append(String.format("%-35s", time));
+		log.append(LocalDateTime.now().format(formatter));
 
 		switch (state) {
 		case ENTER:

--- a/src/main/java/sim/model/Logger.java
+++ b/src/main/java/sim/model/Logger.java
@@ -6,18 +6,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class Logger {
-	// Don't want millisecond precious for a log file, space at end to distinguish column
-	DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss ");
-
-	//enums for the add() method
-	public enum OrderState {
-		ENTER,
-		EXIT,
-		PROCESSED,
-		ENTERKITCHEN,
-		EXITKITCHEN,
-		SERVED;
-	}
+	// Don't want millisecond precious for a log file
+	DateTimeFormatter formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
 
 	private static Logger instance;
 	private StringBuilder log;
@@ -26,60 +16,16 @@ public class Logger {
 		log = new StringBuilder();
 	}
 
-	//adds an entry in the log when an order is added to queue (enter), removed from queue (exit) or processed (processed)
-	public synchronized void add(Customer c, OrderState state, QueueType q) {
-		log.append(LocalDateTime.now().format(formatter));
-
-		switch (state) {
-		case ENTER:
-			switch (q) {
-				case CUSTOMER:
-					log.append(String.format("%-24s", "Enter Normal queue"));
-					break;
-				default:
-					log.append(String.format("%-24s", "Enter Priority queue"));
-					break;
-			}
-			break;
-		case EXIT:
-			switch (q) {
-				case CUSTOMER:
-					log.append(String.format("%-24s", "Exit Normal queue"));
-					break;
-				default:
-					log.append(String.format("%-24s", "Exit Priority queue"));
-					break;
-			}
-			break;
-		case PROCESSED:
-			switch (q) {
-				case CUSTOMER:
-					log.append(String.format("%-24s", "Processed"));
-					break;
-				default:
-					log.append(String.format("%-24s", "Processed Priority"));
-					break;
-			}
-			break;
-
-		case ENTERKITCHEN:
-			log.append(String.format("%-24s", "Enter kitchen"));
-			break;
-
-		case EXITKITCHEN:
-			log.append(String.format("%-24s", "Exit kitchen"));
-			break;
-
-		case SERVED:
-			log.append(String.format("%-24s", "Served"));
-			break;
-		}
-
-		log.append(String.format("%-25s", "Customer: " + c.getName()));
-		for (MenuItem item : c.getOrder()) {
-			log.append(item.getName() + " ");
-		}
-		log.append("\n");
+	/**
+	 * Logs a new simulation event in the log
+	 * @param formatString event message where %s will be replaced with the customer name
+	 * @param customer customer object the event relates to
+	 */
+	public synchronized void add(String formatString, Customer customer) {
+		log.append(String.format("%s %s%n",
+			LocalDateTime.now().format(formatter),
+			String.format(formatString, customer.getName())
+		));
 	}
 
 	// Laze-loads the singleton instance of the class

--- a/src/main/java/sim/model/Logger.java
+++ b/src/main/java/sim/model/Logger.java
@@ -10,25 +10,33 @@ public class Logger {
 	DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
 
 	private static Logger instance;
-	private StringBuilder log;
+	private StringBuilder sBuilder;
 
 	private Logger() {
-		log = new StringBuilder();
+		sBuilder = new StringBuilder();
 	}
 
 	/**
-	 * Logs a new simulation event in the log
-	 * @param formatString event message where %s will be replaced with the customer name
-	 * @param customer customer object the event relates to
+	 * Logs a new string in the log (adds time and newline)
+	 * @param string
 	 */
-	public synchronized void add(String formatString, Customer customer) {
-		log.append(String.format("%s %s%n",
+	public synchronized void add(String string) {
+		sBuilder.append(String.format("%s %s%n",
 			LocalDateTime.now().format(formatter),
-			String.format(formatString, customer.getName())
+			string
 		));
 	}
 
-	// Laze-loads the singleton instance of the class
+	/**
+	 * Logs a new simulation event in the log (adds time and newline)
+	 * @param event event message where %s will be replaced with the customer name
+	 * @param customer customer object the event relates to
+	 */
+	public synchronized void add(String event, Customer customer) {
+		add(String.format(event, customer.getName()));
+	}
+
+	// Lazy-loads the singleton instance of the class
 	// Synchronized whole method to avoid double-checked locking
 	// (shown in lectures, but discouraged in modern Java practice)
 	public static synchronized Logger getInstance() {
@@ -40,7 +48,7 @@ public class Logger {
 	//writes log to file
 	public void writeReport(String filename) {
         try (FileWriter orderWriter = new FileWriter(filename)) {
-			orderWriter.write(log.toString());
+			orderWriter.write(sBuilder.toString());
 		} catch(IOException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/sim/model/Logger.java
+++ b/src/main/java/sim/model/Logger.java
@@ -91,10 +91,6 @@ public class Logger {
 		return instance;
 	}
 
-	public StringBuilder getLog() {
-		return log;
-	}
-
 	//writes log to file
 	public void writeReport(String filename) {
         try (FileWriter orderWriter = new FileWriter(filename)) {

--- a/src/main/java/sim/model/Producer.java
+++ b/src/main/java/sim/model/Producer.java
@@ -19,6 +19,9 @@ public class Producer implements Runnable {
     private SharedQueue out; // customers go here
     private Menu menu; // orders refer to menu
 
+	// Need to log incoming customers
+	private Logger log = Logger.getInstance();
+
     private String frontOfLine; // Customer currently at the front of the line
     private LinkedList<MenuItem> basket = new LinkedList<>(); // Contains orders for customer at front of line
 
@@ -94,10 +97,14 @@ public class Producer implements Runnable {
         }
     }
 
-    // Produce a new customer from the front of the line and their basket
     private void checkout() {
-        out.add(new Customer(frontOfLine, basket.toArray(MenuItem[]::new)));
-        basket.clear();
+		// Produce a new customer from the front of the line and their basket
+		Customer newArrival = new Customer(frontOfLine, basket.toArray(MenuItem[]::new));
+		basket.clear();
+
+		// Add the customer to the service queue and log the event
+        out.add(newArrival);
+		log.add("%s joins the queue", newArrival);
     }
 
     private String[] processLine(String line) {

--- a/src/main/java/sim/model/QueueType.java
+++ b/src/main/java/sim/model/QueueType.java
@@ -1,7 +1,0 @@
-package sim.model;
-
-public enum QueueType {
-	CUSTOMER,
-	KITCHEN,
-	PRIORITY;
-}

--- a/src/main/java/sim/model/Server.java
+++ b/src/main/java/sim/model/Server.java
@@ -61,6 +61,13 @@ public class Server implements Runnable, Subject {
 
                 // Update model state with new customer
                 notifyObservers();
+				log.add(
+					String.format(
+						"Server %d starts serving %s",
+						number,
+						toServe.getName()
+					)
+				);
 
                 try {
                     // Time to process order depends on number of items
@@ -70,6 +77,7 @@ public class Server implements Runnable, Subject {
                 }
 
                 // Pass order on to kitchen queue
+                kitchenQueue.add(toServe);
 				log.add(
 					String.format(
 						"Server %d sends an order to the kitchen for %s",
@@ -77,7 +85,6 @@ public class Server implements Runnable, Subject {
 						toServe.getName()
 					)
 				);
-                kitchenQueue.add(toServe);
 
                 // Update model state to reflect customer served
                 currentCustomer = Optional.empty();

--- a/src/main/java/sim/model/Server.java
+++ b/src/main/java/sim/model/Server.java
@@ -61,7 +61,7 @@ public class Server implements Runnable, Subject {
                 }
 
                 // Pass order on to kitchen queue
-                log.add(toServe, Logger.OrderState.PROCESSED, target.getQueueType());
+                log.add("A server sends an order to the kitchen for %s", toServe);
                 kitchenQueue.add(toServe);
 
                 // Update model state to reflect customer served

--- a/src/main/java/sim/model/Server.java
+++ b/src/main/java/sim/model/Server.java
@@ -7,7 +7,13 @@ import sim.interfaces.Observer;
 import sim.interfaces.Subject;
 
 public class Server implements Runnable, Subject {
-    private SharedQueue customerQueue, kitchenQueue, priorityQueue;
+	// Static variable tracks number of servers that exist
+	private static int count = 0;
+	private int number = 0; // Each new server gets a unique number ID
+
+    private SharedQueue customerQueue;
+	private SharedQueue kitchenQueue;
+	private SharedQueue priorityQueue;
     private LinkedList<Observer> observers;
     private Logger log;
     private long speed;
@@ -25,6 +31,9 @@ public class Server implements Runnable, Subject {
         this.customerQueue = customerQueue;
         this.kitchenQueue = kitchenQueue;
         this.priorityQueue = priorityQueue;
+
+		// Increment server number
+		this.number = ++count;
 
         observers = new LinkedList<>();
         log = Logger.getInstance();
@@ -61,7 +70,13 @@ public class Server implements Runnable, Subject {
                 }
 
                 // Pass order on to kitchen queue
-                log.add("A server sends an order to the kitchen for %s", toServe);
+				log.add(
+					String.format(
+						"Server %d sends an order to the kitchen for %s",
+						number,
+						toServe.getName()
+					)
+				);
                 kitchenQueue.add(toServe);
 
                 // Update model state to reflect customer served
@@ -115,4 +130,8 @@ public class Server implements Runnable, Subject {
     public boolean isDone() {
         return done;
     }
+
+	public int getNumber() {
+		return number;
+	}
 }

--- a/src/main/java/sim/model/SharedQueue.java
+++ b/src/main/java/sim/model/SharedQueue.java
@@ -11,20 +11,12 @@ public class SharedQueue implements Subject {
     // The underlying shared object
 	private LinkedList<Customer> queue = new LinkedList<>();
 
-    // Queue logs entry/exit events
-    private Logger log = Logger.getInstance();
-    private QueueType queueType;
-
     // Observers register themselves here for notifications
 	private LinkedList<Observer> observers = new LinkedList<>();
 
     // Flags for producer/consumers to check object state
     private boolean empty = true;
     private boolean done = false;
-
-	public SharedQueue (QueueType queueType) {
-		this.queueType = queueType;
-	}
 
 	// Returns a customer from the top of the queue (once/if there is one)
 	public synchronized Optional<Customer> getCustomer() {
@@ -45,18 +37,6 @@ public class SharedQueue implements Subject {
 
 		Customer customer = queue.removeFirst();
 
-		switch (queueType) {
-            case CUSTOMER:
-                log.add(customer, Logger.OrderState.EXITKITCHEN, QueueType.CUSTOMER);
-                break;
-            case KITCHEN:
-                log.add(customer, Logger.OrderState.EXITKITCHEN, QueueType.KITCHEN);
-                break;
-            default:
-                log.add(customer, Logger.OrderState.EXIT, QueueType.PRIORITY);
-                break;
-		}
-
         // No need to notify threads as producer never needs to wait
 		if (queue.isEmpty()) {
 			empty = true;
@@ -75,18 +55,6 @@ public class SharedQueue implements Subject {
         // Producer never needs to wait since we're dealing with a queue
 		queue.addLast(c);
         empty = false;
-
-        // Log every addition to the queue
-		switch (queueType) {
-            case CUSTOMER:
-                log.add(c, Logger.OrderState.ENTERKITCHEN, QueueType.CUSTOMER);
-                break;
-            case KITCHEN:
-                log.add(c, Logger.OrderState.ENTERKITCHEN, QueueType.KITCHEN);
-                break;
-            default:
-                log.add(c, Logger.OrderState.ENTER, QueueType.PRIORITY);
-		}
 
         // Inform all consumers and observers that the queue is no longer empty
 		notifyAll();
@@ -135,9 +103,5 @@ public class SharedQueue implements Subject {
 		for (Observer o : observers) {
 			o.update();
 		}
-	}
-
-	public QueueType getQueueType() {
-		return queueType;
 	}
 }

--- a/src/main/java/sim/views/ServerGUI.java
+++ b/src/main/java/sim/views/ServerGUI.java
@@ -26,11 +26,7 @@ import sim.model.MenuItem;
 import sim.model.Server;
 
 public class ServerGUI extends JPanel implements Observer {
-	// Static variable tracks number of servers that exist
-	private static int count = 0;
-
 	private Server server;
-	private int number;
 
 	private JTextArea serverArea;
 	private JSlider serverSlider;
@@ -42,7 +38,6 @@ public class ServerGUI extends JPanel implements Observer {
 
 	public ServerGUI(Server server) {
 		this.server = server;
-		this.number = ++count;
 		server.registerObserver(this);
 		setLayout(new GridLayout(2,1));
 		add(setupControls());
@@ -56,7 +51,7 @@ public class ServerGUI extends JPanel implements Observer {
 		serverArea = new JTextArea();
 		serverArea.setEditable(false);
 		serverArea.setFont(new Font("Monospaced", Font.PLAIN, 12));
-		Border border1 = BorderFactory.createTitledBorder("Server " + number);
+		Border border1 = BorderFactory.createTitledBorder("Server " + server.getNumber());
 		JScrollPane serverPane = new JScrollPane(serverArea);
 		setBorder(border1);
 		add(serverPane);


### PR DESCRIPTION
- Remove the hardcoding of logged events (also removes need for queue types)
- Move logging out of the queue class (makes sense that events come from entities in the simulation)
- Log simulation start/end and service start/end
- Improve output format of event lines in the log (no millisecond precision or date necessary for the timescales of this simulation)

Closes #100 